### PR TITLE
Bluexpdoc 358 and CQP link fixes

### DIFF
--- a/_whatsnew/2023-07-04.adoc
+++ b/_whatsnew/2023-07-04.adoc
@@ -4,4 +4,4 @@ When you activate Cloud Tiering, ONTAP can use an unlimited amount of network ba
 === Tiering event displayed in the Notification Center
 The tiering event "Tier additional data from cluster <name> to object storage to increase your storage efficiency" now appears as a notification when a cluster is tiering less than 20% of its cold data - including clusters that are tiering no data.
 
-This notification is a "Recommendation" to help make your systems more efficient and to save on storage costs. It provides a link to the https://bluexp.netapp.com/cloud-tiering-service-tco[Cloud Tiering total cost of ownership and savings calculator^] to help you calculate your cost savings.
+This notification is a "Recommendation" to help make your systems more efficient and to save on storage costs. It provides a link to the https://www.netapp.com/data-services/tiering/tco-calculator/[Cloud Tiering total cost of ownership and savings calculator^] to help you calculate your cost savings.

--- a/concept-cloud-tiering.adoc
+++ b/concept-cloud-tiering.adoc
@@ -21,7 +21,7 @@ Originally supported on AFF, FAS, and ONTAP Select systems with all-SSD aggregat
 
 You can configure tiering for single-node clusters, HA-configured clusters, clusters in Tiering Mirror configurations, and MetroCluster configurations using FabricPool Mirror. Cloud Tiering licenses are shared among all of your clusters. 
 
-https://bluexp.netapp.com/cloud-tiering-service-tco[Use the Cloud Tiering TCO calculator to see how much money you can save^].
+https://www.netapp.com/data-services/tiering/tco-calculator/[Use the Cloud Tiering TCO calculator to see how much money you can save^].
 
 == NetApp Console 
 
@@ -61,7 +61,7 @@ You can tier inactive data from an on-premises ONTAP system to the following obj
 * NetApp StorageGRID
 * S3-compatible object storage (for example, MinIO)
 
-Cloud Tiering licenses can also be shared with your clusters that are tiering data to IBM Cloud Object Storage. The FabricPool configuration must be set up using System Manager or the ONTAP CLI, but link:task-licensing-cloud-tiering.html#apply-bluexp-tiering-licenses-to-clusters-in-special-configurations[licensing for this type of configuration is completed using Cloud Tiering.]
+Cloud Tiering licenses can also be shared with your clusters that are tiering data to IBM Cloud Object Storage. The FabricPool configuration must be set up using System Manager or the ONTAP CLI, but link:task-licensing-cloud-tiering.html#apply-cloud-tiering-licenses-to-clusters-in-special-configurations[licensing for this type of configuration is completed using Cloud Tiering.]
 
 NOTE: You can tier data from NAS volumes to the public cloud or to private clouds, like StorageGRID. When you tier data that is accessed by SAN protocols, NetApp recommends using private clouds due to connectivity considerations.
 
@@ -109,7 +109,7 @@ For example, if you have a 10 TB license, all capacity beyond the 10 TB is charg
 
 You won't be charged from your pay-as-you-go subscription during your free trial or if you haven't exceeded your Cloud Tiering BYOL license.
 
-link:task-licensing-cloud-tiering.html#use-a-bluexp-tiering-paygo-subscription[Learn how to set up a pay-as-you-go subscription].
+link:task-licensing-cloud-tiering.html#use-a-cloud-tiering-paygo-subscription[Learn how to set up a pay-as-you-go subscription].
 
 === Annual contract
 
@@ -121,11 +121,11 @@ Annual contracts are not currently supported when tiering to Google CLoud.
 
 Bring your own license by purchasing a *Cloud Tiering* license from NetApp (previously known as a "Cloud Tiering" license). You can purchase 1-, 2-, or 3-year term licenses and specify any amount of tiering capacity (starting at a minimum of 10 TiB). The BYOL Cloud Tiering license is a _floating_ license that you can use across multiple on-premises ONTAP clusters. The total tiering capacity that you define in your Cloud Tiering license can be used by all of your on-premises clusters.
 
-After you purchase a Cloud Tiering license, you'll need add the license to the NetApp Console. link:task-licensing-cloud-tiering.html#use-a-bluexp-tiering-byol-license[See how to use a Cloud Tiering BYOL license].
+After you purchase a Cloud Tiering license, you'll need add the license to the NetApp Console. link:task-licensing-cloud-tiering.html#use-a-cloud-tiering-byol-license[See how to use a Cloud Tiering BYOL license].
 
 As noted above, we recommend that you set up a pay-as-you-go subscription, even if you have purchased a BYOL license.
 
-NOTE: Starting August 2021 the old *FabricPool* license was replaced by the *Cloud Tiering* license. link:task-licensing-cloud-tiering.html#bluexp-tiering-byol-licensing-starting-in-2021[Read more about how the Cloud Tiering license is different than the FabricPool license].
+NOTE: Starting August 2021 the old *FabricPool* license was replaced by the *Cloud Tiering* license. link:task-licensing-cloud-tiering.html#cloud-tiering-byol-licensing-starting-in-2021[Read more about how the Cloud Tiering license is different than the FabricPool license].
 
 == How Cloud Tiering works
 

--- a/faq-cloud-tiering.adoc
+++ b/faq-cloud-tiering.adoc
@@ -117,7 +117,7 @@ Yes. Check https://aws.amazon.com/s3/pricing/[Amazon S3 Pricing], https://azure.
 
 === How can I estimate my volumes' savings and get a cold data report before I enable Cloud Tiering?
 
-To get an estimate, add your ONTAP cluster to the NetApp Console and inspect it through the Cloud Tiering Clusters page. Select *Calculate potential tiering savings* for the cluster to launch the https://bluexp.netapp.com/cloud-tiering-service-tco[Cloud Tiering TCO calculator^] to see how much money you can save.
+To get an estimate, add your ONTAP cluster to the NetApp Console and inspect it through the Cloud Tiering Clusters page. Select *Calculate potential tiering savings* for the cluster to launch the https://www.netapp.com/data-services/tiering/tco-calculator[Cloud Tiering TCO calculator^] to see how much money you can save.
 
 === How am I charged for tiering when I am using an ONTAP MetroCluster?
 

--- a/faq-cloud-tiering.adoc
+++ b/faq-cloud-tiering.adoc
@@ -151,7 +151,7 @@ If you have Cloud Volumes ONTAP systems, you'll find them in the Cloud Tiering C
 
 It depends on where you tier the cold data. Refer to the following links for more details:
 
-* link:task-tiering-onprem-aws.html#prepare-your-ontap-cluster[Tiering data to Amazon S3]
+* link:task-tiering-onprem-aws.html#preparing-your-ontap-clusters[Tiering data to Amazon S3]
 * link:task-tiering-onprem-azure.html#preparing-your-ontap-clusters[Tiering data to Azure Blob storage]
 * link:task-tiering-onprem-gcp.html#preparing-your-ontap-clusters[Tiering data to Google Cloud Storage]
 * link:task-tiering-onprem-storagegrid.html#preparing-your-ontap-clusters[Tiering data to StorageGRID]

--- a/task-licensing-cloud-tiering.adoc
+++ b/task-licensing-cloud-tiering.adoc
@@ -31,6 +31,7 @@ If you don't have a Cloud Tiering license, a 30-day free trial of Cloud Tiering 
 
 If your free trial ends and you haven't subscribed or added a license, then ONTAP no longer tiers cold data to object storage. All previously tiered data remains accessible; meaning you can retrieve and use this data. When retrieved, this data is moved back to the performance tier from the cloud. 
 
+[[use-a-cloud-tiering-paygo-subscription]]
 == Use a Cloud Tiering PAYGO subscription
 
 Pay-as-you-go subscriptions from your cloud provider's marketplace enable you to license the use of Cloud Volumes ONTAP systems and many Cloud Data Services, such as Cloud Tiering.
@@ -95,6 +96,7 @@ When tiering inactive data to Azure, you can subscribe to an annual contract fro
 
 Annual contracts are not currently supported when tiering to Google Cloud.
 
+[[use-a-cloud-tiering-byol-license]]
 == Use a Cloud Tiering BYOL license
 
 Bring-your-own licenses from NetApp provide 1-, 2-, or 3-year terms. The BYOL *Cloud Tiering* license (previously known as a "Cloud Tiering" license) is a _floating_ license that you can use across multiple on-premises ONTAP clusters in your NetApp Console organization. The total tiering capacity defined in your Cloud Tiering license is shared among *all* of your on-premises clusters, making initial licensing and renewal easy. The minimum capacity for a tiering BYOL license starts at 10 TiB.
@@ -108,6 +110,7 @@ Optionally, if you have an unassigned node-based license for Cloud Volumes ONTAP
 
 You manage Cloud Tiering BYOL licenses in the Console. You can add new licenses and update existing licenses. link:https://docs.netapp.com/us-en/bluexp-digital-wallet/task-manage-data-services-licenses.html[Learn how to manage licenses.^]
 
+[[cloud-tiering-byol-licensing-starting-in-2021]]
 === Cloud Tiering BYOL licensing starting in 2021
 
 The new *Cloud Tiering* license was introduced in August 2021 for tiering configurations that are supported within the NetApp Console using the Cloud Tiering service. The NetApp Console currently supports tiering to the following cloud storage: Amazon S3, Azure Blob storage, Google Cloud Storage, NetApp StorageGRID, and S3-compatible object storage.
@@ -141,6 +144,7 @@ If your licensed term is nearing the expiration date, or if your licensed capaci
 
 You can update existing licenses, view license status, and add new licenses through the Console. https://docs.netapp.com/us-en/bluexp-digital-wallet/task-manage-data-services-licenses.html[Learn about managing licenses^].
 
+[[apply-cloud-tiering-licenses-to-clusters-in-special-configurations]]
 == Apply Cloud Tiering licenses to clusters in special configurations
 
 ONTAP clusters in the following configurations can use Cloud Tiering licenses, but the license must be applied in a different manner than single-node clusters, HA-configured clusters, clusters in Tiering Mirror configurations, and MetroCluster configurations using FabricPool Mirror:
@@ -150,7 +154,7 @@ ONTAP clusters in the following configurations can use Cloud Tiering licenses, b
 
 === Process for existing clusters that have a FabricPool license
 
-When you link:task-managing-tiering.html#discovering-additional-clusters-from-bluexp-tiering[discover any of these special cluster types in Cloud Tiering], Cloud Tiering recognizes the FabricPool license and adds the license to the Console. Those clusters will continue tiering data as usual. When the FabricPool license expires, you'll need to purchase a Cloud Tiering license.
+When you link:task-managing-tiering.html#discovering-additional-clusters-from-cloud-tiering[discover any of these special cluster types in Cloud Tiering], Cloud Tiering recognizes the FabricPool license and adds the license to the Console. Those clusters will continue tiering data as usual. When the FabricPool license expires, you'll need to purchase a Cloud Tiering license.
 
 === Process for newly created clusters
 
@@ -171,11 +175,11 @@ Note that since data is tiered to two different object storage locations for Tie
 +
 Do not configure tiering at this point.
 
-. link:task-licensing-cloud-tiering.html#use-a-bluexp-tiering-byol-license[Purchase a Cloud Tiering license] for the capacity needed for the new cluster, or clusters.
+. link:task-licensing-cloud-tiering.html#use-a-cloud-tiering-byol-license[Purchase a Cloud Tiering license] for the capacity needed for the new cluster, or clusters.
 
 . In the Console <<licenses,add the license to the digital wallet>>[add the license].
 
-. In Cloud Tiering, link:task-managing-tiering.html#discovering-additional-clusters-from-bluexp-tiering[discover the new clusters].
+. In Cloud Tiering, link:task-managing-tiering.html#discovering-additional-clusters-from-cloud-tiering[discover the new clusters].
 
 . From the Clusters page, select image:screenshot_horizontal_more_button.gif[More icon] for the cluster and select *Deploy License*.
 +

--- a/task-managing-object-storage.adoc
+++ b/task-managing-object-storage.adoc
@@ -29,6 +29,7 @@ This example shows both an Amazon S3 and Azure Blob object store attached to dif
 +
 image:screenshot_tiering_object_store_view.png["A screenshot that shows the object storage information, which details total used capacity, aggregate attached to the object store, name of the object store, and more information."]
 
+[[adding-a-new-object-store]]
 == Add a new object store
 
 You can add a new object store for aggregates in your cluster. After you create it, you can attach it to an aggregate.
@@ -75,6 +76,7 @@ The object store is created.
 
 Now you can attach the object store to an aggregate in your cluster.
 
+[[attaching-a-second-object-store-to-an-aggregate-for-mirroring]]
 == Attach a second object store to an aggregate for mirroring
 
 You can attach a second object store to an aggregate to create a FabricPool mirror to synchronously tier data to two object stores. You must have one object store already attached to the aggregate. https://docs.netapp.com/us-en/ontap/fabricpool/create-mirror-task.html[Learn more about FabricPool mirrors^].
@@ -101,6 +103,7 @@ image:screenshot_tiering_mirror_config_complete.png["A screenshot showing a seco
 
 The Mirror status will appear as "Sync in progress" while the 2 object stores are synchronizing. The status will change to "Synchronized" when synchronization is complete.
 
+[[swapping-the-primary-and-mirror-object-store]]
 == Swap the primary and mirror object store
 
 You can swap the primary and mirror object store for an aggregate. The object store mirror becomes the primary, and the original primary becomes the mirror.
@@ -117,6 +120,7 @@ image:screenshot_tiering_mirror_swap.png["A screenshot showing the Swap Destinat
 
 . Approve the action in the dialog box and the primary and mirror objects stores are swapped.
 
+[[removing-a-mirror-object-store-from-an-aggregate]]
 == Remove a mirror object store from an aggregate
 
 You can remove a FabricPool mirror if you no longer need to replicate to an additional object store.

--- a/task-managing-tiering.adoc
+++ b/task-managing-tiering.adoc
@@ -15,6 +15,7 @@ summary: Now that you've set up data tiering from your on-premises ONTAP cluster
 [.lead]
 Now that you've set up data tiering from your on-premises ONTAP clusters, you can tier data from additional volumes, change a volume's tiering policy, discover additional clusters, and more by using NetApp Cloud Tiering.
 
+[[reviewing-tiering-info-for-a-cluster]]
 == Review tiering info for a cluster
 
 Check the data in the cloud tier, on disks, or the amount of hot and cold data on the cluster's disks. Or, you might want to see the amount of hot and cold data on the cluster's disks. Cloud Tiering provides this information for each cluster.
@@ -39,6 +40,7 @@ You can also https://docs.netapp.com/us-en/active-iq/task-informed-decisions-bas
 
 image:screenshot_tiering_aiq_fabricpool_info.png["A screenshot that shows FabricPool information for a cluster using the FabricPool Advisor from Digital Advisor."]
 
+[[tiering-data-from-additional-volumes]]
 == Tier data from additional volumes
 
 Set up data tiering for additional volumes at any time--for example, after creating a new volume.
@@ -72,6 +74,7 @@ image:screenshot_tiering_policy_settings.png[A screenshot that shows the configu
 
 ONTAP starts tiering the selected volumes' data to the cloud.
 
+[[changing-a-volumes-tiering-policy]]
 == Change a volume's tiering policy
 
 Changing the tiering policy for a volume changes how ONTAP tiers cold data to object storage. The change starts from the moment that you change the policy. It changes only the subsequent tiering behavior for the volume--it does not retroactively move data to the cloud tier.
@@ -94,6 +97,7 @@ NOTE: If you see options to "Retrieve Tiered Data", see <<Migrate data from the 
 
 ONTAP changes the tiering policy and begins tiering data based on the new policy.
 
+[[changing-the-network-bandwidth-available-to-upload-inactive-data-to-object-storage]]
 == Change the network bandwidth available to upload inactive data to object storage
 
 When you activate Cloud Tiering for a cluster, by default, ONTAP can use an unlimited amount of bandwidth to transfer the inactive data from volumes in system to object storage. If tiering traffic affects user workloads, throttle the network bandwidth used during the transfer. You can choose a value between 1 and 10,000 Mbps as the maximum transfer rate.
@@ -116,6 +120,7 @@ Download a report of the Tier Volumes page so you can review the tiering status 
 
 image:screenshot_tiering_report_download.png[A screenshot showing how to generate a CSV file listing the tiering status of all your volumes.]
 
+[[migrating-data-from-the-cloud-tier-back-to-the-performance-tier]]
 == Migrate data from the cloud tier back to the performance tier
 
 Tiered data that is accessed from the cloud may be "re-heated" and moved back to the performance tier. However, if you want to proactively promote data to the performance tier from the cloud tier, you can do this in the _Tiering Policy_ dialog. This capability is available when using ONTAP 9.8 and greater.
@@ -152,6 +157,7 @@ image:screenshot_tiering_policy_settings_with_retrieve.png[A screenshot that sho
 
 The tiering policy is changed and the tiered data starts to be migrated back to the performance tier. Depending on the amount of data in the cloud, the transfer process could take some time.
 
+[[managing-tiering-settings-on-aggregates]]
 == Manage tiering settings on aggregates
 
 Each aggregate in your on-premises ONTAP systems has two settings that you can adjust: the tiering fullness threshold and whether inactive data reporting is enabled.
@@ -198,6 +204,7 @@ If failures occur, Cloud Tiering displays a "Failed" operational health status o
 
 .. Verify that the Console has outbound connections to the Cloud Tiering service, to the object store, and to the ONTAP clusters that it discovers.
 
+[[discovering-additional-clusters-from-cloud-tiering]]
 == Discover additional clusters from Cloud Tiering
 
 You can add your undiscovered on-premises ONTAP clusters to the Console from the Tiering _Cluster_ page so that you can enable tiering for the cluster.

--- a/task-monitor-tiering-alerts.adoc
+++ b/task-monitor-tiering-alerts.adoc
@@ -21,7 +21,7 @@ At this time, there is one tiering event that will appear as a notification:
 
 Tier additional data from cluster <name> to object storage to save storage space
 
-This notification is a "Recommendation" to improve system efficiency and reduce storage costs. It indicates that a cluster is tiering less than 20% of its cold data - including clusters that are tiering no data. It provides a link to the https://bluexp.netapp.com/cloud-tiering-service-tco[Cloud Tiering total cost of ownership and savings calculator^] to help you calculate your cost savings.
+This notification is a "Recommendation" to improve system efficiency and reduce storage costs. It indicates that a cluster is tiering less than 20% of its cold data - including clusters that are tiering no data. It provides a link to the https://www.netapp.com/data-services/tiering/tco-calculator/[Cloud Tiering total cost of ownership and savings calculator^] to help you calculate your cost savings.
 
 The NetApp Console does not send an email for this notification.
 

--- a/task-tiering-onprem-aws.adoc
+++ b/task-tiering-onprem-aws.adoc
@@ -109,6 +109,7 @@ If you already have an agent deployed in your AWS VPC or on your premises, then 
 
 * If you have a Direct Connect or VPN connection from your ONTAP cluster to the VPC, and you want communication between the agent and S3 to stay in your AWS internal network (a *private* connection), you'll need to enable a VPC Endpoint interface to S3. <<Configure your system for a private connection using a VPC endpoint interface,See how to set up a VPC endpoint interface.>>
 
+[[preparing-your-ontap-clusters]]
 == Prepare your ONTAP cluster
 
 Your ONTAP clusters must meet the following requirements when tiering data to Amazon S3.
@@ -161,6 +162,7 @@ By default, Cloud tiering creates the bucket for you. If you want to use your ow
 
 NOTE: If you are planning to configure Cloud Tiering to use a lower cost storage class where your tiered data will transition to after a certain number of days, you must not select any lifecycle rules when setting up the bucket in your AWS account. Cloud Tiering manages the lifecycle transitions.
 
+[[set-up-s3-permissions]]
 === Set up S3 permissions
 
 You'll need to configure two sets of permissions:

--- a/task-tiering-onprem-azure.adoc
+++ b/task-tiering-onprem-azure.adoc
@@ -54,6 +54,7 @@ image:diagram_cloud_tiering_azure.png["An architecture image that shows the Clou
 
 NOTE: Communication between the Console agent and Blob storage is for object storage setup only. The agent can reside on your premises, instead of in the cloud.
 
+[[preparing-your-ontap-clusters]]
 === Prepare your ONTAP clusters
 
 Your ONTAP clusters must meet the following requirements when tiering data to Azure Blob storage.
@@ -101,7 +102,7 @@ An agent is required to tier data to the cloud. When tiering data to Azure Blob 
 
 === Verify that you have the necessary agent permissions
 
-If you created the Console agent using version 3.9.25 or greater, then you're all set. The custom role that provides the permissions that an agent needs to manage resources and processes within your Azure network will be set up by default. See the https://docs.netapp.com/us-en/bluexp-setup-admin/reference-permissions-azure.html#custom-role-permissions[required custom role permissions^] and the https://docs.netapp.com/us-en/bluexp-setup-admin/reference-permissions-azure.html#cloud-tiering[specific permissions required for Cloud Tiering^].
+If you created the Console agent using version 3.9.25 or greater, then you're all set. The custom role that provides the permissions that an agent needs to manage resources and processes within your Azure network will be set up by default. See the https://docs.netapp.com/us-en/console-setup-admin/reference-permissions-azure.html[required custom role permissions^] and the https://docs.netapp.com/us-en/console-setup-admin/reference-permissions-azure.html#tiering[specific permissions required for Cloud Tiering^].
 
 If you created the agent using an earlier version, then you'll need to edit the permission list for the Azure account to add any missing permissions.
 

--- a/task-tiering-onprem-gcp.adoc
+++ b/task-tiering-onprem-gcp.adoc
@@ -54,6 +54,7 @@ image:diagram_cloud_tiering_google.png["An architecture image that shows the Clo
 
 NOTE: Communication between the agent and Google Cloud Storage is for object storage setup only.
 
+[[preparing-your-ontap-clusters]]
 === Prepare your ONTAP clusters
 
 Your ONTAP clusters must meet the following requirements when tiering data to Google Cloud Storage.
@@ -113,6 +114,7 @@ Ensure that the Console agent has the required networking connections.
 +
 https://cloud.google.com/vpc/docs/configure-private-google-access[Private Google Access^] is recommended if you have a direct connection from your ONTAP cluster to the VPC and you want communication between the agent and Google Cloud Storage to stay in your virtual private network. Note that Private Google Access works with VM instances that have only internal (private) IP addresses (no external IP addresses).
 
+[[preparing-google-cloud-storage]]
 === Prepare Google Cloud Storage
 
 When you set up tiering, you need to provide storage access keys for a service account that has Storage Admin permissions. A service account enables Cloud Tiering to authenticate and access Cloud Storage buckets used for data tiering. The keys are required so that Google Cloud Storage knows who is making the request.

--- a/task-tiering-onprem-s3-compat.adoc
+++ b/task-tiering-onprem-s3-compat.adoc
@@ -66,6 +66,7 @@ image:diagram_cloud_tiering_s3_compat.png["An architecture image that shows the 
 
 NOTE: Communication between the agent and the S3-compatible object storage server is for object storage setup only.
 
+[[preparing-your-ontap-clusters]]
 === Prepare your ONTAP clusters
 
 Your source ONTAP clusters must meet the following requirements when tiering data to S3-compatible object storage.
@@ -103,6 +104,7 @@ https://docs.netapp.com/us-en/bluexp-ontap-onprem/task-discovering-ontap.html[Le
 
 S3-compatible object storage must meet the following requirements.
 
+[[preparing-s3-compatible-object-storage]]
 S3 credentials::
 When you set up tiering to S3-compatible object storage, you're prompted to create an S3 bucket or to select an existing S3 bucket. You need to provide Cloud Tiering with an S3 access key and secret key. Cloud Tiering uses the keys to access your bucket.
 +

--- a/task-tiering-onprem-storagegrid.adoc
+++ b/task-tiering-onprem-storagegrid.adoc
@@ -45,6 +45,7 @@ image:diagram_cloud_tiering_storagegrid.png["An architecture image that shows th
 
 NOTE: Communication between the agent and StorageGRID is for object storage setup only.
 
+[[preparing-your-ontap-clusters]]
 === Prepare your ONTAP clusters
 
 Your ONTAP clusters must meet the following requirements when tiering data to StorageGRID.
@@ -89,6 +90,7 @@ StorageGRID must meet the following requirements.
 Supported StorageGRID versions::
 StorageGRID 10.3 and later is supported.
 
+[[preparing-storagegrid]]
 S3 credentials::
 When you set up tiering to StorageGRID, you need to provide Cloud Tiering with an S3 access key and secret key. Cloud Tiering uses the keys to access your buckets.
 +


### PR DESCRIPTION
This pull request primarily updates documentation to improve clarity and consistency for Cloud Tiering features. The main changes include updating URLs to point to the latest resources, standardizing link anchors and references, and adding new section anchors for easier navigation. These changes enhance the user experience by ensuring all references are accurate and documentation is easier to follow.

**Documentation Improvements:**

* Updated all references to the Cloud Tiering TCO calculator to use the new NetApp URL (`https://www.netapp.com/data-services/tiering/tco-calculator/`) for consistency and accuracy. [[1]](diffhunk://#diff-9de71f5cf385d49d9d0f4c4c9bf1a2ba84112bf24da8fa0cfa88a8547a352c73L7-R7) [[2]](diffhunk://#diff-e8e0d2bdcddb94754e72543f0e20f0d7ab096d7fa21bb5ec517376e2c0690a27L24-R24) [[3]](diffhunk://#diff-ef63287cd4d4ecd773856cadd9bbf62f8761b078157b1a15e93f32951c2fe577L120-R120)
* Standardized internal documentation links and anchors, such as replacing "bluexp" with "cloud-tiering" in various links and updating section anchors for licensing and cluster discovery. [[1]](diffhunk://#diff-e8e0d2bdcddb94754e72543f0e20f0d7ab096d7fa21bb5ec517376e2c0690a27L64-R64) [[2]](diffhunk://#diff-e8e0d2bdcddb94754e72543f0e20f0d7ab096d7fa21bb5ec517376e2c0690a27L112-R112) [[3]](diffhunk://#diff-e8e0d2bdcddb94754e72543f0e20f0d7ab096d7fa21bb5ec517376e2c0690a27L124-R128) [[4]](diffhunk://#diff-aee87b9acb9d5994dc95b5d9db58f40b3626cde26cfeac75b893ba45ee83a351R34) [[5]](diffhunk://#diff-aee87b9acb9d5994dc95b5d9db58f40b3626cde26cfeac75b893ba45ee83a351R99) [[6]](diffhunk://#diff-aee87b9acb9d5994dc95b5d9db58f40b3626cde26cfeac75b893ba45ee83a351R113) [[7]](diffhunk://#diff-aee87b9acb9d5994dc95b5d9db58f40b3626cde26cfeac75b893ba45ee83a351R147) [[8]](diffhunk://#diff-aee87b9acb9d5994dc95b5d9db58f40b3626cde26cfeac75b893ba45ee83a351L153-R157) [[9]](diffhunk://#diff-aee87b9acb9d5994dc95b5d9db58f40b3626cde26cfeac75b893ba45ee83a351L174-R182) [[10]](diffhunk://#diff-ef63287cd4d4ecd773856cadd9bbf62f8761b078157b1a15e93f32951c2fe577L154-R154)

**Navigation and Structure Enhancements:**

* Added new section anchors throughout the documentation (e.g., `[[use-a-cloud-tiering-paygo-subscription]]`, `[[reviewing-tiering-info-for-a-cluster]]`, `[[adding-a-new-object-store]]`) to improve navigation and make it easier to link to specific instructions. [[1]](diffhunk://#diff-aee87b9acb9d5994dc95b5d9db58f40b3626cde26cfeac75b893ba45ee83a351R34) [[2]](diffhunk://#diff-aee87b9acb9d5994dc95b5d9db58f40b3626cde26cfeac75b893ba45ee83a351R99) [[3]](diffhunk://#diff-aee87b9acb9d5994dc95b5d9db58f40b3626cde26cfeac75b893ba45ee83a351R113) [[4]](diffhunk://#diff-aee87b9acb9d5994dc95b5d9db58f40b3626cde26cfeac75b893ba45ee83a351R147) [[5]](diffhunk://#diff-fd52c38890c704a249a84b7bbe7e203358aa7dc1ad65b5293ed59ac8a8ecdf2bR32) [[6]](diffhunk://#diff-fd52c38890c704a249a84b7bbe7e203358aa7dc1ad65b5293ed59ac8a8ecdf2bR79) [[7]](diffhunk://#diff-fd52c38890c704a249a84b7bbe7e203358aa7dc1ad65b5293ed59ac8a8ecdf2bR106) [[8]](diffhunk://#diff-fd52c38890c704a249a84b7bbe7e203358aa7dc1ad65b5293ed59ac8a8ecdf2bR123) [[9]](diffhunk://#diff-fe947c465b01b3fb91192ed1f68f40dfc0f710c437178f96b064c6c085c8b305R18) [[10]](diffhunk://#diff-fe947c465b01b3fb91192ed1f68f40dfc0f710c437178f96b064c6c085c8b305R43) [[11]](diffhunk://#diff-fe947c465b01b3fb91192ed1f68f40dfc0f710c437178f96b064c6c085c8b305R77) [[12]](diffhunk://#diff-fe947c465b01b3fb91192ed1f68f40dfc0f710c437178f96b064c6c085c8b305R100) [[13]](diffhunk://#diff-fe947c465b01b3fb91192ed1f68f40dfc0f710c437178f96b064c6c085c8b305R123) [[14]](diffhunk://#diff-fe947c465b01b3fb91192ed1f68f40dfc0f710c437178f96b064c6c085c8b305R160) [[15]](diffhunk://#diff-fe947c465b01b3fb91192ed1f68f40dfc0f710c437178f96b064c6c085c8b305R207)

These updates ensure that users have access to the most current resources and that documentation is easier to navigate and maintain.