### PR TITLE
Bluexpdoc 1130 fabricpool

### DIFF
--- a/_whatsnew/2026-04-13.adoc
+++ b/_whatsnew/2026-04-13.adoc
@@ -1,4 +1,15 @@
 
-include::../_include/cloud-tiering-eol.adoc[]
+
+=== NetApp Cloud Tiering no longer offered
+
+NetApp Cloud Tiering is no longer available for purchase or license renewal as of April 26, 2026.
+
+Existing customers can continue to use and receive support for NetApp Cloud Tiering until their subscription or license contract expires. After the subscription expires, customers will no longer have access to NetApp Cloud Tiering features or support.
+
+NetApp recommends customers work with their NetApp representative to transition their existing tiering licenses to ONTAP FabricPool licenses, which provides the functionality for data tiering in ONTAP. See link:https://docs.netapp.com/us-en/ontap/fabricpool/install-license-aws-azure-ibm-task.html[Install a FabricPool license on an ONTAP cluster] for more information on how to set up data tiering in ONTAP using FabricPool.
+
+* link:https://go.digital.netapp.com/rs/683-HWH-936/images/Cloud-Tiering-EOA-Notice2.pdf?version=0&mkt_tok=NjgzLUhXSC05MzYAAAGgvTOT_9L2PauNXYE0fOs0RIz8KK2q5Jb6sg8Yv-97NNJ53ceAab9UAqpKOrAvByxsOWqhIQHNCHgFfM0q3TI[NetApp Cloud Tiering End of Availability Notice]
+
+* link:https://go.digital.netapp.com/rs/683-HWH-936/images/Cloud-Tiering-EOA-FAQ-v3.pdf?version=0&mkt_tok=NjgzLUhXSC05MzYAAAGgvTOT_rplJe_ZtlY4PQAQRQlewsDa0W4JR55muT0KCThR46zI7-uOhIYfVsxODDKFrnYYvy5uZzvhEKHOwBI[NetApp Cloud Tiering End of Availability FAQ]
 
 

--- a/task-tiering-onprem-aws.adoc
+++ b/task-tiering-onprem-aws.adoc
@@ -1,7 +1,7 @@
 ---
 sidebar: sidebar
 permalink: task-tiering-onprem-aws.html
-keywords: data tiering, fabricpool, cloud tiering, tiering cold data, tiering inactive data, tiering aff, tiering fas, tiering ontap, tiering volumes, tier data, tier cold data, tier fas, tier aff, tier ontap, aws, amazon, s3
+keywords: data tiering, fabricpool, cloud tiering, tiering cold data, tiering inactive data, tiering aff, tiering fas, tiering ontap, tiering volumes, tier data, tier cold data, tier fas, tier aff, tier ontap, aws, amazon, s3 tiering
 summary: Free space on your on-premises ONTAP clusters by tiering inactive data to Amazon S3.
 summary: Free space on your on-premises ONTAP clusters by tiering inactive data to Amazon S3.
 ---


### PR DESCRIPTION
This pull request announces the end of availability for NetApp Cloud Tiering and provides guidance for affected customers. It also makes a minor update to the keywords in the AWS tiering task documentation.

**NetApp Cloud Tiering End of Availability Announcement:**

* Added a new section to `_whatsnew/2026-04-13.adoc` announcing that NetApp Cloud Tiering will no longer be available for purchase or license renewal as of April 26, 2026, with recommendations for transitioning to ONTAP FabricPool licenses and links to official notices and FAQs.

**Documentation Update:**

* Updated the `keywords` field in `task-tiering-onprem-aws.adoc` to include "s3 tiering" for improved searchability.